### PR TITLE
feat(postgresql): add reusable chart and auxarmormy overlay

### DIFF
--- a/argo-apps/auxarmormy-oci.yaml
+++ b/argo-apps/auxarmormy-oci.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: auxarmormy-oci
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.slack: deployments
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: deployments
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: deployments
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Dumspy/k8s-manifest
+    path: charts/postgresql
+    targetRevision: HEAD
+    helm:
+      releaseName: auxarmormy
+      valueFiles:
+        - values.yaml
+        - deployments/auxarmormy.yaml
+  destination:
+    name: oci-cluster
+    namespace: postgres
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postgresql
+description: Reusable single PostgreSQL database chart
+type: application
+version: 0.3.2
+appVersion: "16.9"

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -1,0 +1,80 @@
+# postgresql
+
+This chart deploys a single PostgreSQL instance with persistent storage.
+
+It includes:
+
+- A PostgreSQL `StatefulSet`
+- Internal services for the database pod
+- A `OnePasswordItem` for the database password
+
+Shared chart defaults live in `values.yaml`. Deployment-specific overrides live in `deployments/*.yaml`.
+
+## Deployment Overrides
+
+Create one override file per database deployment under `deployments/` and reference it from ArgoCD with `valueFiles`.
+
+Example override for the OCI `auxarmormy` deployment:
+
+```yaml
+database:
+  name: auxarmormy
+  user: auxarmormy
+
+onePassword:
+  itemPath: vaults/p364xm4f4uub6cfyzweulklgwa/items/knuooys23mo5jluzxkct5fgeyi
+```
+
+This keeps shared storage, resource, and image defaults in the chart while letting each deployment use its own database name, user, and secret item.
+
+## 1Password Requirements
+
+The chart creates a `OnePasswordItem` named `<release-name>-secret` using:
+
+- `onePassword.itemPath`, typically from a deployment override in `deployments/*.yaml`
+
+That 1Password item must expose this field:
+
+- `password`: password for the PostgreSQL user defined by `database.user`
+
+## How The Secret Is Used
+
+The `password` key is consumed by:
+
+- PostgreSQL startup, as `POSTGRES_PASSWORD`
+- The password sync hook in the StatefulSet
+
+## Expected 1Password Item Shape
+
+At minimum, the referenced 1Password item should include a field named `password`.
+
+Example:
+
+```text
+Item: postgres-db
+Field: password = <strong password>
+```
+
+## Template Fallback
+
+If `onePassword.itemPath` is omitted, the template falls back to:
+
+```yaml
+onePassword:
+  itemPath: vaults/ksplpxkiblaftafiljqytehbcy/items/postgres-cluster
+```
+
+`database.name`, `database.user`, and `onePassword.itemPath` are typically set per deployment in `deployments/*.yaml`.
+
+Example ArgoCD values files:
+
+```yaml
+valueFiles:
+  - values.yaml
+  - deployments/auxarmormy.yaml
+```
+
+## Services
+
+- `{{ .Release.Name }}-headless` supports the StatefulSet network identity.
+- `{{ .Release.Name }}-direct` is the stable client service for PostgreSQL access.

--- a/charts/postgresql/deployments/auxarmormy.yaml
+++ b/charts/postgresql/deployments/auxarmormy.yaml
@@ -1,0 +1,8 @@
+# Auxarmormy PostgreSQL deployment overrides for the OCI cluster.
+
+database:
+  name: auxarmormy
+  user: auxarmormy
+
+onePassword:
+  itemPath: "vaults/p364xm4f4uub6cfyzweulklgwa/items/knuooys23mo5jluzxkct5fgeyi"

--- a/charts/postgresql/templates/1password-item.yaml
+++ b/charts/postgresql/templates/1password-item.yaml
@@ -1,0 +1,11 @@
+{{- $onePassword := .Values.onePassword | default dict -}}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Release.Name }}-secret
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ $onePassword.itemPath | default "vaults/ksplpxkiblaftafiljqytehbcy/items/postgres-cluster" | quote }}

--- a/charts/postgresql/templates/service-headless.yaml
+++ b/charts/postgresql/templates/service-headless.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-headless
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: {{ .Release.Name }}
+    component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.service.directPort }}
+      targetPort: postgres

--- a/charts/postgresql/templates/service-postgres.yaml
+++ b/charts/postgresql/templates/service-postgres.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-direct
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: {{ .Release.Name }}
+    component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.service.directPort }}
+      targetPort: postgres

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -1,0 +1,107 @@
+{{- $database := .Values.database | default dict -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  serviceName: {{ .Release.Name }}-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      component: postgres
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        component: postgres
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -c
+            - max_connections={{ .Values.extraConfig.maxConnections }}
+            - -c
+            - shared_buffers={{ .Values.extraConfig.sharedBuffers }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.service.directPort }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ $database.name | default "postgres" | quote }}
+            - name: POSTGRES_USER
+              value: {{ $database.user | default "postgres" | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secret
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - |
+                    until pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                      sleep 2
+                    done
+
+                    psql \
+                      --username "$POSTGRES_USER" \
+                      --dbname "$POSTGRES_DB" \
+                      --set=ON_ERROR_STOP=1 \
+                      --set=postgres_user="$POSTGRES_USER" \
+                      --set=postgres_password="$POSTGRES_PASSWORD" <<'EOSQL'
+                    DO
+                    $do$
+                    BEGIN
+                      EXECUTE 'ALTER ROLE '
+                        || quote_ident(:'postgres_user')
+                        || ' WITH LOGIN SUPERUSER PASSWORD '
+                        || quote_literal(:'postgres_password');
+                    END
+                    $do$;
+                    EOSQL
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size | quote }}

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,0 +1,28 @@
+# Shared defaults. Deployment-specific database and secret values live in deployments/*.yaml.
+
+image:
+  repository: postgres
+  tag: "16.9-alpine"
+  pullPolicy: IfNotPresent
+
+service:
+  directPort: 5432
+
+storage:
+  className: local-path
+  size: 20Gi
+
+nodeSelector:
+  role: database
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
+extraConfig:
+  maxConnections: 200
+  sharedBuffers: 256MB


### PR DESCRIPTION
## Summary
- Replace the old umbrella PostgreSQL/PgBouncer chart with a reusable single-PostgreSQL chart.
- Add a per-deployment override for the OCI `auxarmormy` install and point ArgoCD at it.
- Document shared defaults, deployment overrides, and the 1Password-backed password flow.

## Validation
- `helm lint charts/postgresql`
- `helm template charts/postgresql | kubectl apply --dry-run=client -f -`
- `helm template charts/postgresql -f charts/postgresql/deployments/auxarmormy.yaml | kubectl apply --dry-run=client -f -`