### PR TITLE
feat(auxarmory): add umbrella deployment chart

### DIFF
--- a/argo-apps/auxarmory.yaml
+++ b/argo-apps/auxarmory.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: auxarmory
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.slack: deployments
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: deployments
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: deployments
+    notifications.argoproj.io/subscribe.on-image-updated.slack: deployments
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Dumspy/k8s-manifest
+    path: charts/auxarmory
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    name: oci-cluster
+    namespace: auxarmory
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argo-apps/cloudflare-tunnel-oci.yaml
+++ b/argo-apps/cloudflare-tunnel-oci.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: auxarmormy-postgres
+  name: cloudflare-tunnel-oci
   namespace: argocd
   annotations:
     notifications.argoproj.io/subscribe.on-deployed.slack: deployments
     notifications.argoproj.io/subscribe.on-sync-failed.slack: deployments
     notifications.argoproj.io/subscribe.on-health-degraded.slack: deployments
+    notifications.argoproj.io/subscribe.on-rollback.slack: deployments
 spec:
   project: default
   source:
     repoURL: https://github.com/Dumspy/k8s-manifest
-    path: charts/postgresql
+    path: charts/cloudflare-tunnel
     targetRevision: HEAD
     helm:
-      releaseName: auxarmormy-postgres
       valueFiles:
         - values.yaml
-        - deployments/auxarmormy-postgres.yaml
+        - values-oci.yaml
   destination:
     name: oci-cluster
-    namespace: postgres
+    namespace: production
   syncPolicy:
     automated:
       prune: true

--- a/charts/auxarmory/Chart.lock
+++ b/charts/auxarmory/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: file://../postgresql
+  version: 0.3.3
+- name: redis
+  repository: file://../redis
+  version: 0.1.0
+digest: sha256:a8618e454697529b2e8fa99b884ffb9999148bec53f45e06559def4100a34c3a
+generated: "2026-04-06T00:24:21.128355332Z"

--- a/charts/auxarmory/Chart.yaml
+++ b/charts/auxarmory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auxarmory
 description: AuxArmory umbrella chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 dependencies:
   - name: postgresql

--- a/charts/auxarmory/Chart.yaml
+++ b/charts/auxarmory/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: auxarmory
+description: AuxArmory umbrella chart
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+  - name: postgresql
+    version: 0.3.3
+    repository: file://../postgresql
+    condition: postgresql.enabled
+  - name: redis
+    version: 0.1.0
+    repository: file://../redis
+    condition: redis.enabled

--- a/charts/auxarmory/README.md
+++ b/charts/auxarmory/README.md
@@ -26,6 +26,7 @@ Recommended hostnames:
 ## 1Password Layout
 
 Create these 1Password items and point `values.yaml` at their item paths.
+The current `values.yaml` uses placeholder item paths, so fill those in before rollout.
 
 ### Shared item
 

--- a/charts/auxarmory/README.md
+++ b/charts/auxarmory/README.md
@@ -1,0 +1,82 @@
+# auxarmory
+
+Umbrella Helm chart for AuxArmory on Kubernetes.
+
+## Components
+
+This chart deploys:
+
+- `web`
+- `auth`
+- `api`
+- `worker-service`
+- local `postgresql` dependency
+- local `redis` dependency
+- Argo Image Updater config for the four runtime images
+- label-based `NetworkPolicy` resources
+
+Public routing is expected to come from the shared Cloudflare Tunnel managed in `/home/nixos/Documents/infra-tofu`.
+
+Recommended hostnames:
+
+- `armory.rger.dev`
+- `auth.armory.rger.dev`
+- `api.armory.rger.dev`
+
+## 1Password Layout
+
+Create these 1Password items and point `values.yaml` at their item paths.
+
+### Shared item
+
+- `DATABASE_URL`
+- `REDIS_URL`
+- `INTERNAL_API_TOKEN`
+
+### Web item
+
+- `VITE_SENTRY_DSN`
+
+### Auth item
+
+- `BETTER_AUTH_SECRET`
+- `SENTRY_DSN`
+- `BATTLENET_CLIENT_ID`
+- `BATTLENET_CLIENT_SECRET`
+- `WARCRAFTLOGS_CLIENT_ID`
+- `WARCRAFTLOGS_CLIENT_SECRET`
+
+### API item
+
+- `SENTRY_DSN`
+
+### Worker item
+
+- `SENTRY_DSN`
+- `BATTLENET_CLIENT_ID`
+- `BATTLENET_CLIENT_SECRET`
+- `BATTLE_NET_ACCOUNT_TOKEN`
+
+### Postgres item
+
+- `POSTGRES_PASSWORD`
+
+## Migration Hook
+
+The migration hook is present but disabled by default through `migration.enabled=false`.
+
+The intended execution path is to reuse the `api` image as an ArgoCD `PreSync` Job once that image is confirmed to support:
+
+```bash
+pnpm --filter @auxarmory/db db:migrate
+```
+
+If the current image cannot run that command as-is, the next step is to file the upstream issue captured in the deployment plan before enabling the hook here.
+
+## Validation
+
+```bash
+helm dependency update charts/auxarmory
+helm lint charts/auxarmory
+helm template charts/auxarmory | kubectl apply --dry-run=client -f -
+```

--- a/charts/auxarmory/templates/_helpers.tpl
+++ b/charts/auxarmory/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{- define "auxarmory.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.labels" -}}
+app.kubernetes.io/managed-by: Helm
+app.kubernetes.io/part-of: auxarmory
+app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+{{- end -}}
+
+{{- define "auxarmory.web.name" -}}
+{{- printf "%s-web" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.auth.name" -}}
+{{- printf "%s-auth" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.api.name" -}}
+{{- printf "%s-api" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.worker.name" -}}
+{{- printf "%s-worker" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.sharedSecretName" -}}
+{{- printf "%s-shared-secret" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.webSecretName" -}}
+{{- printf "%s-web-secret" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.authSecretName" -}}
+{{- printf "%s-auth-secret" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.apiSecretName" -}}
+{{- printf "%s-api-secret" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.workerSecretName" -}}
+{{- printf "%s-worker-secret" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.webConfigMapName" -}}
+{{- printf "%s-web-config" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.authConfigMapName" -}}
+{{- printf "%s-auth-config" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.apiConfigMapName" -}}
+{{- printf "%s-api-config" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auxarmory.workerConfigMapName" -}}
+{{- printf "%s-worker-config" (include "auxarmory.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/auxarmory/templates/api-deployment.yaml
+++ b/charts/auxarmory/templates/api-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auxarmory.api.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: api
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "auxarmory.labels" . | nindent 8 }}
+        app.kubernetes.io/name: api
+        network.rger.dev/public-tunnel: "true"
+        network.rger.dev/access-postgres: "true"
+        network.rger.dev/access-redis: "true"
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "auxarmory.apiConfigMapName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.sharedSecretName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.apiSecretName" . }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}

--- a/charts/auxarmory/templates/auth-deployment.yaml
+++ b/charts/auxarmory/templates/auth-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auxarmory.auth.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: auth
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  replicas: {{ .Values.auth.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth
+      app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "auxarmory.labels" . | nindent 8 }}
+        app.kubernetes.io/name: auth
+        network.rger.dev/public-tunnel: "true"
+        network.rger.dev/access-postgres: "true"
+    spec:
+      containers:
+        - name: auth
+          image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
+          imagePullPolicy: {{ .Values.auth.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.auth.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "auxarmory.authConfigMapName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.sharedSecretName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.authSecretName" . }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.auth.resources | nindent 12 }}

--- a/charts/auxarmory/templates/configmaps.yaml
+++ b/charts/auxarmory/templates/configmaps.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "auxarmory.webConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: web
+data:
+  NODE_ENV: {{ .Values.global.nodeEnv | quote }}
+  VITE_APP_NAME: {{ .Values.global.appName | quote }}
+  VITE_APP_URL: {{ printf "https://%s" .Values.global.hosts.web | quote }}
+  VITE_AUTH_URL: {{ printf "https://%s" .Values.global.hosts.auth | quote }}
+  VITE_API_URL: {{ printf "https://%s" .Values.global.hosts.api | quote }}
+  VITE_SENTRY_ENV: {{ .Values.global.sentry.environment | quote }}
+  VITE_SENTRY_TRACES_SAMPLE_RATE: {{ .Values.global.sentry.tracesSampleRate | quote }}
+  VITE_SENTRY_RELEASE: {{ .Values.global.sentry.release | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "auxarmory.authConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: auth
+data:
+  NODE_ENV: {{ .Values.global.nodeEnv | quote }}
+  AUTH_SERVICE_PORT: {{ .Values.auth.service.port | quote }}
+  AUTH_SERVICE_ORIGIN: {{ printf "http://%s:%v" (include "auxarmory.auth.name" .) .Values.auth.service.port | quote }}
+  WEB_ORIGIN: {{ printf "https://%s" .Values.global.hosts.web | quote }}
+  BETTER_AUTH_URL: {{ printf "https://%s" .Values.global.hosts.auth | quote }}
+  AUTH_TRUSTED_ORIGINS: {{ printf "https://%s" .Values.global.hosts.web | quote }}
+  AUTH_COOKIE_DOMAIN: {{ .Values.global.cookieDomain | quote }}
+  SENTRY_ENV: {{ .Values.global.sentry.environment | quote }}
+  SENTRY_TRACES_SAMPLE_RATE: {{ .Values.global.sentry.tracesSampleRate | quote }}
+  SENTRY_RELEASE: {{ .Values.global.sentry.release | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "auxarmory.apiConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: api
+data:
+  NODE_ENV: {{ .Values.global.nodeEnv | quote }}
+  API_SERVICE_PORT: {{ .Values.api.service.port | quote }}
+  API_SERVICE_ORIGIN: {{ printf "http://%s:%v" (include "auxarmory.api.name" .) .Values.api.service.port | quote }}
+  WEB_ORIGIN: {{ printf "https://%s" .Values.global.hosts.web | quote }}
+  SENTRY_ENV: {{ .Values.global.sentry.environment | quote }}
+  SENTRY_TRACES_SAMPLE_RATE: {{ .Values.global.sentry.tracesSampleRate | quote }}
+  SENTRY_RELEASE: {{ .Values.global.sentry.release | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "auxarmory.workerConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: worker
+data:
+  NODE_ENV: {{ .Values.global.nodeEnv | quote }}
+  API_SERVICE_ORIGIN: {{ printf "http://%s:%v" (include "auxarmory.api.name" .) .Values.api.service.port | quote }}
+  FAILURE_SINK_TIMEOUT_MS: {{ .Values.worker.failureSinkTimeoutMs | quote }}
+  SENTRY_ENV: {{ .Values.global.sentry.environment | quote }}
+  SENTRY_TRACES_SAMPLE_RATE: {{ .Values.global.sentry.tracesSampleRate | quote }}
+  SENTRY_RELEASE: {{ .Values.global.sentry.release | quote }}

--- a/charts/auxarmory/templates/db-migrate-job.yaml
+++ b/charts/auxarmory/templates/db-migrate-job.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-db-migrate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: migration
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "auxarmory.labels" . | nindent 8 }}
+        app.kubernetes.io/name: migration
+        network.rger.dev/access-postgres: "true"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: db-migrate
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.migration.command | nindent 12 }}
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.global.nodeEnv | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ include "auxarmory.sharedSecretName" . }}
+{{- end }}

--- a/charts/auxarmory/templates/db-migrate-job.yaml
+++ b/charts/auxarmory/templates/db-migrate-job.yaml
@@ -21,14 +21,18 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: db-migrate
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
+          {{- if .Values.migration.command }}
           command:
             {{- toYaml .Values.migration.command | nindent 12 }}
+          {{- end }}
           env:
             - name: NODE_ENV
               value: {{ .Values.global.nodeEnv | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "auxarmory.sharedSecretName" . }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
 {{- end }}

--- a/charts/auxarmory/templates/image-updater.yaml
+++ b/charts/auxarmory/templates/image-updater.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.imageUpdater.enabled }}
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: {{ include "auxarmory.fullname" . }}
+  namespace: argocd
+spec:
+  namespace: argocd
+  applicationRefs:
+    - namePattern: {{ include "auxarmory.fullname" . }}
+      images:
+        - alias: web
+          imageName: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          commonUpdateSettings:
+            updateStrategy: digest
+          manifestTargets:
+            helm:
+              name: web.image.repository
+              tag: web.image.tag
+        - alias: auth
+          imageName: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
+          commonUpdateSettings:
+            updateStrategy: digest
+          manifestTargets:
+            helm:
+              name: auth.image.repository
+              tag: auth.image.tag
+        - alias: api
+          imageName: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          commonUpdateSettings:
+            updateStrategy: digest
+          manifestTargets:
+            helm:
+              name: api.image.repository
+              tag: api.image.tag
+        - alias: worker
+          imageName: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          commonUpdateSettings:
+            updateStrategy: digest
+          manifestTargets:
+            helm:
+              name: worker.image.repository
+              tag: worker.image.tag
+{{- end }}

--- a/charts/auxarmory/templates/networkpolicies.yaml
+++ b/charts/auxarmory/templates/networkpolicies.yaml
@@ -1,0 +1,95 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-default-deny-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-allow-public-tunnel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      network.rger.dev/public-tunnel: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: production
+          podSelector:
+            matchLabels:
+              app: cloudflare-tunnel
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-allow-internal-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              network.rger.dev/access-api: "true"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-allow-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Values.postgresql.fullnameOverride }}
+      app.kubernetes.io/component: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              network.rger.dev/access-postgres: "true"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auxarmory.fullname" . }}-allow-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: {{ .Values.redis.fullnameOverride }}
+      app.kubernetes.io/component: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              network.rger.dev/access-redis: "true"

--- a/charts/auxarmory/templates/onepassword-items.yaml
+++ b/charts/auxarmory/templates/onepassword-items.yaml
@@ -1,0 +1,59 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "auxarmory.sharedSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ .Values.global.onePassword.sharedItemPath | quote }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "auxarmory.webSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ .Values.web.onePassword.itemPath | quote }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "auxarmory.authSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ .Values.auth.onePassword.itemPath | quote }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "auxarmory.apiSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ .Values.api.onePassword.itemPath | quote }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "auxarmory.workerSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  itemPath: {{ .Values.worker.onePassword.itemPath | quote }}

--- a/charts/auxarmory/templates/services.yaml
+++ b/charts/auxarmory/templates/services.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auxarmory.web.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: web
+spec:
+  selector:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auxarmory.auth.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: auth
+spec:
+  selector:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  ports:
+    - name: http
+      port: {{ .Values.auth.service.port }}
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auxarmory.api.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: api
+spec:
+  selector:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: http

--- a/charts/auxarmory/templates/web-deployment.yaml
+++ b/charts/auxarmory/templates/web-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auxarmory.web.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: web
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+      app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "auxarmory.labels" . | nindent 8 }}
+        app.kubernetes.io/name: web
+        network.rger.dev/public-tunnel: "true"
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "auxarmory.webConfigMapName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.webSecretName" . }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}

--- a/charts/auxarmory/templates/worker-deployment.yaml
+++ b/charts/auxarmory/templates/worker-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auxarmory.worker.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auxarmory.labels" . | nindent 4 }}
+    app.kubernetes.io/name: worker
+  annotations:
+    operator.1password.io/auto-restart: "true"
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+      app.kubernetes.io/instance: {{ include "auxarmory.fullname" . }}
+  template:
+    metadata:
+      labels:
+        {{- include "auxarmory.labels" . | nindent 8 }}
+        app.kubernetes.io/name: worker
+        network.rger.dev/access-api: "true"
+        network.rger.dev/access-postgres: "true"
+        network.rger.dev/access-redis: "true"
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "auxarmory.workerConfigMapName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.sharedSecretName" . }}
+            - secretRef:
+                name: {{ include "auxarmory.workerSecretName" . }}
+          # livenessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: http
+          #   initialDelaySeconds: 30
+          #   periodSeconds: 10
+          #   timeoutSeconds: 5
+          # readinessProbe:
+          #   httpGet:
+          #     path: /ready
+          #     port: http
+          #   initialDelaySeconds: 5
+          #   periodSeconds: 5
+          #   timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}

--- a/charts/auxarmory/values.yaml
+++ b/charts/auxarmory/values.yaml
@@ -1,0 +1,108 @@
+global:
+  nodeEnv: production
+  appName: AuxArmory
+  hosts:
+    web: armory.rger.dev
+    auth: auth.armory.rger.dev
+    api: api.armory.rger.dev
+  cookieDomain: armory.rger.dev
+  sentry:
+    environment: production
+    tracesSampleRate: 0.1
+    release: ""
+  onePassword:
+    sharedItemPath: vaults/replace-me/items/replace-me
+
+imageUpdater:
+  enabled: true
+
+web:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/dumspy/auxarmory-web
+    tag: latest
+    pullPolicy: Always
+  service:
+    port: 3000
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  onePassword:
+    itemPath: vaults/replace-me/items/replace-me
+
+auth:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/dumspy/auxarmory-auth
+    tag: latest
+    pullPolicy: Always
+  service:
+    port: 4000
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  onePassword:
+    itemPath: vaults/replace-me/items/replace-me
+
+api:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/dumspy/auxarmory-api
+    tag: latest
+    pullPolicy: Always
+  service:
+    port: 4001
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  onePassword:
+    itemPath: vaults/replace-me/items/replace-me
+
+worker:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/dumspy/auxarmory-worker-service
+    tag: latest
+    pullPolicy: Always
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  failureSinkTimeoutMs: 400
+  onePassword:
+    itemPath: vaults/replace-me/items/replace-me
+
+migration:
+  enabled: false
+  command:
+    - /bin/sh
+    - -ec
+    - pnpm --filter @auxarmory/db db:migrate
+
+postgresql:
+  enabled: true
+  fullnameOverride: auxarmory-postgres
+  database:
+    name: auxarmory
+    user: auxarmory
+  onePassword:
+    itemPath: vaults/replace-me/items/replace-me
+
+redis:
+  enabled: true
+  fullnameOverride: auxarmory-redis

--- a/charts/auxarmory/values.yaml
+++ b/charts/auxarmory/values.yaml
@@ -11,6 +11,7 @@ global:
     tracesSampleRate: 0.1
     release: ""
   onePassword:
+    # TODO: fill in the shared 1Password item path.
     sharedItemPath: vaults/replace-me/items/replace-me
 
 imageUpdater:
@@ -32,6 +33,7 @@ web:
       memory: "512Mi"
       cpu: "500m"
   onePassword:
+    # TODO: fill in the web 1Password item path.
     itemPath: vaults/replace-me/items/replace-me
 
 auth:
@@ -50,6 +52,7 @@ auth:
       memory: "512Mi"
       cpu: "500m"
   onePassword:
+    # TODO: fill in the auth 1Password item path.
     itemPath: vaults/replace-me/items/replace-me
 
 api:
@@ -68,6 +71,7 @@ api:
       memory: "512Mi"
       cpu: "500m"
   onePassword:
+    # TODO: fill in the api 1Password item path.
     itemPath: vaults/replace-me/items/replace-me
 
 worker:
@@ -85,6 +89,7 @@ worker:
       cpu: "500m"
   failureSinkTimeoutMs: 400
   onePassword:
+    # TODO: fill in the worker 1Password item path.
     itemPath: vaults/replace-me/items/replace-me
 
 migration:
@@ -101,6 +106,7 @@ postgresql:
     name: auxarmory
     user: auxarmory
   onePassword:
+    # TODO: fill in the postgres 1Password item path.
     itemPath: vaults/replace-me/items/replace-me
 
 redis:

--- a/charts/auxarmory/values.yaml
+++ b/charts/auxarmory/values.yaml
@@ -93,11 +93,18 @@ worker:
     itemPath: vaults/replace-me/items/replace-me
 
 migration:
-  enabled: false
-  command:
-    - /bin/sh
-    - -ec
-    - pnpm --filter @auxarmory/db db:migrate
+  enabled: true
+  image:
+    repository: ghcr.io/dumspy/auxarmory-db-migrations
+    tag: latest
+    pullPolicy: Always
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 postgresql:
   enabled: true

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Cloudflare Tunnel for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2026.1.2"

--- a/charts/cloudflare-tunnel/templates/1password-item.yaml
+++ b/charts/cloudflare-tunnel/templates/1password-item.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ .Release.Name }}-secret
   namespace: {{ .Release.Namespace }}
 spec:
-  itemPath: "vaults/ksplpxkiblaftafiljqytehbcy/items/rfy6l2ltizlsfipgcvm2ycez64"
+  itemPath: {{ .Values.cloudflared.onePassword.itemPath | quote }}

--- a/charts/cloudflare-tunnel/values-oci.yaml
+++ b/charts/cloudflare-tunnel/values-oci.yaml
@@ -1,0 +1,4 @@
+cloudflared:
+  onePassword:
+    # TODO: fill in the OCI tunnel 1Password item path.
+    itemPath: vaults/replace-me/items/replace-me

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -16,3 +16,5 @@ cloudflared:
 
   logLevel: info
   metricsPort: 2000
+  onePassword:
+    itemPath: vaults/ksplpxkiblaftafiljqytehbcy/items/rfy6l2ltizlsfipgcvm2ycez64

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -10,6 +10,22 @@ It includes:
 
 Shared chart defaults live in `values.yaml`. Deployment-specific overrides live in `deployments/*.yaml`.
 
+## Reuse As A Dependency
+
+This chart can be used standalone or as a dependency inside an umbrella chart.
+
+When used as a dependency, set `fullnameOverride` so resource names stay distinct from the parent release, for example:
+
+```yaml
+postgresql:
+  fullnameOverride: auxarmory-postgres
+```
+
+Optional naming values:
+
+- `fullnameOverride`: resource prefix used for the StatefulSet, services, and generated secret name
+- `secretNameOverride`: explicit override for the synced 1Password secret name
+
 ## Deployment Overrides
 
 Create one override file per database deployment under `deployments/` and reference it from ArgoCD with `valueFiles`.

--- a/charts/postgresql/templates/1password-item.yaml
+++ b/charts/postgresql/templates/1password-item.yaml
@@ -2,8 +2,10 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Release.Name }}-secret
+  name: {{ include "postgresql.secretName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "0"
     operator.1password.io/auto-restart: "true"

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{- define "postgresql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.secretName" -}}
+{{- if .Values.secretNameOverride -}}
+{{- .Values.secretNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-secret" (include "postgresql.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.labels" -}}
+app.kubernetes.io/name: postgresql
+app.kubernetes.io/instance: {{ include "postgresql.fullname" . }}
+app.kubernetes.io/component: postgres
+{{- end -}}

--- a/charts/postgresql/templates/service-headless.yaml
+++ b/charts/postgresql/templates/service-headless.yaml
@@ -1,13 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-headless
+  name: {{ include "postgresql.fullname" . }}-headless
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
   selector:
-    app: {{ .Release.Name }}
+    app: {{ include "postgresql.fullname" . }}
     component: postgres
   ports:
     - name: postgres

--- a/charts/postgresql/templates/service-postgres.yaml
+++ b/charts/postgresql/templates/service-postgres.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-direct
+  name: {{ include "postgresql.fullname" . }}-direct
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   selector:
-    app: {{ .Release.Name }}
+    app: {{ include "postgresql.fullname" . }}
     component: postgres
   ports:
     - name: postgres

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -2,21 +2,24 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "postgresql.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  serviceName: {{ .Release.Name }}-headless
+  serviceName: {{ include "postgresql.fullname" . }}-headless
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ include "postgresql.fullname" . }}
       component: postgres
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}
+        {{- include "postgresql.labels" . | nindent 8 }}
+        app: {{ include "postgresql.fullname" . }}
         component: postgres
     spec:
       nodeSelector:
@@ -41,7 +44,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-secret
+                  name: {{ include "postgresql.secretName" . }}
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,5 +1,8 @@
 # Shared defaults. Deployment-specific database and secret values live in deployments/*.yaml.
 
+fullnameOverride: ""
+secretNameOverride: ""
+
 image:
   repository: postgres
   tag: "16.9-alpine"

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: redis
+description: Reusable single Redis chart
+type: application
+version: 0.1.0
+appVersion: "8.2.1"

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,0 +1,20 @@
+# redis
+
+This chart deploys a single Redis instance with persistent storage.
+
+It includes:
+
+- A Redis `StatefulSet`
+- A headless service for the StatefulSet network identity
+- A stable ClusterIP client service
+
+Default scheduling targets the same `role: database` node pool as PostgreSQL.
+
+When used as a dependency inside an umbrella chart, set `fullnameOverride` so the client service name is predictable, for example:
+
+```yaml
+redis:
+  fullnameOverride: auxarmory-redis
+```
+
+That gives you a stable in-cluster endpoint such as `redis://auxarmory-redis:6379`.

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{- define "redis.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redis.labels" -}}
+app.kubernetes.io/name: redis
+app.kubernetes.io/instance: {{ include "redis.fullname" . }}
+app.kubernetes.io/component: redis
+{{- end -}}

--- a/charts/redis/templates/service-headless.yaml
+++ b/charts/redis/templates/service-headless.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: {{ include "redis.fullname" . }}
+    component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.service.port }}
+      targetPort: redis

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ include "redis.fullname" . }}
+    component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.service.port }}
+      targetPort: redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "redis.fullname" . }}-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "redis.fullname" . }}
+      component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "redis.labels" . | nindent 8 }}
+        app: {{ include "redis.fullname" . }}
+        component: redis
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.service.port }}
+          command:
+            - redis-server
+            - --save
+            - "60"
+            - "1000"
+            - --appendonly
+            - "yes"
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size | quote }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -1,0 +1,24 @@
+fullnameOverride: ""
+
+image:
+  repository: redis
+  tag: "8.2.1-alpine"
+  pullPolicy: IfNotPresent
+
+service:
+  port: 6379
+
+storage:
+  className: local-path
+  size: 5Gi
+
+nodeSelector:
+  role: database
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"


### PR DESCRIPTION
## Summary
- add an `auxarmory` umbrella chart with web, auth, api, worker, shared 1Password wiring, Argo Image Updater, and label-based network policies
- add a reusable local Redis chart and update the PostgreSQL chart so it can be safely consumed as a subchart with naming overrides
- add the OCI ArgoCD app, document the secret layout, and gate the migration hook until upstream API-image migration support lands

## Validation
- `helm lint charts/postgresql`
- `helm lint charts/redis`
- `helm dependency update charts/auxarmory`
- `helm lint charts/auxarmory`
- `helm template auxarmory charts/auxarmory --namespace auxarmory | kubectl apply --dry-run=client -f -`

## Notes
- migration remains disabled via `migration.enabled=false`
- upstream migration blocker tracked in Dumspy/auxarmory#64