### PR TITLE
chore(argocd): update to latest stable release

### DIFF
--- a/charts/argocd/Chart.lock
+++ b/charts/argocd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 9.2.4
+  version: 9.4.17
 - name: argocd-image-updater
   repository: https://argoproj.github.io/argo-helm
-  version: 1.0.4
-digest: sha256:98927fba0871a35d73c5e3e156dbb9e892b0fe387014781063755bd40c948bb3
-generated: "2026-01-22T15:27:00.800367956Z"
+  version: 1.1.4
+digest: sha256:465cc88f020645ed71adce12b2537e8239fb6a1571b75c5aaf0087a98452fa7a
+generated: "2026-04-06T15:14:47.282354142Z"

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: argo-cd
 description: A Helm chart for Kubernetes
 type: application
-version: 0.4.0
+version: 0.4.1
 dependencies:
   - name: argo-cd
-    version: 9.2.4
+    version: 9.4.17
     repository: https://argoproj.github.io/argo-helm
   - name: argocd-image-updater
-    version: 1.0.4
+    version: 1.1.4
     repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
## Summary
- Bump Argo CD to `9.4.17` (`v3.3.6`)
- Bump `argocd-image-updater` to `1.1.4`
- Regenerate `Chart.lock` so the dependency pins stay in sync

## Validation
- `helm lint charts/argocd`
- `helm template charts/argocd | kubectl apply --dry-run=client -f -`
- `kubectl version -o yaml` confirms the cluster is `v1.34.3+k3s1`, which satisfies the chart's `>=1.25.0-0` requirement