### PR TITLE
feat(argocd): enable GitHub SSO

### DIFF
--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-cd
 description: A Helm chart for Kubernetes
 type: application
-version: 0.4.1
+version: 0.5.0
 dependencies:
   - name: argo-cd
     version: 9.4.17

--- a/charts/argocd/templates/github-sso-1password-item.yaml
+++ b/charts/argocd/templates/github-sso-1password-item.yaml
@@ -1,0 +1,9 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.sso.github.secretName }}
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+spec:
+  itemPath: {{ .Values.sso.github.onePasswordItemPath | quote }}

--- a/charts/argocd/templates/github-sso-1password-item.yaml
+++ b/charts/argocd/templates/github-sso-1password-item.yaml
@@ -1,7 +1,7 @@
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Values.sso.github.secretName }}
+  name: argocd-github-sso
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: argocd

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -29,6 +29,9 @@ argo-cd:
             config:
               clientID: $argocd-github-sso:dex.github.clientID
               clientSecret: $argocd-github-sso:dex.github.clientSecret
+              scopes:
+                - user:email
+                - read:org
     params:
       server.insecure: "true"
     rbac:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -11,7 +11,6 @@ argocd-image-updater:
 
 sso:
   github:
-    secretName: argocd-github-sso
     # GitHub OAuth app credentials synced by the 1Password Operator.
     onePasswordItemPath: "vaults/ksplpxkiblaftafiljqytehbcy/items/462rdh47q7hba2aebr4yrktfzy"
 

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -9,13 +9,35 @@ argocd-image-updater:
     install: true
     keep: true
 
+sso:
+  github:
+    secretName: argocd-github-sso
+    # GitHub OAuth app credentials synced by the 1Password Operator.
+    onePasswordItemPath: "vaults/ksplpxkiblaftafiljqytehbcy/items/462rdh47q7hba2aebr4yrktfzy"
+
 argo-cd:
   server:
     service:
-      type: NodePort
+      type: ClusterIP
   configs:
+    cm:
+      url: https://argocd.rger.dev
+      dex.config: |
+        connectors:
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: $argocd-github-sso:dex.github.clientID
+              clientSecret: $argocd-github-sso:dex.github.clientSecret
     params:
       server.insecure: "true"
+    rbac:
+      policy.default: ""
+      # Add one line per GitHub email that should have ArgoCD admin access.
+      policy.csv: |
+        g, felix.enok.berger@gmail.com, role:admin
+      scopes: "[groups, email]"
   notifications:
     enabled: true
     secret:
@@ -50,7 +72,7 @@ argo-cd:
                 },
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]
@@ -82,7 +104,7 @@ argo-cd:
                 {{end}}
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]
@@ -114,7 +136,7 @@ argo-cd:
                 {{end}}
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]
@@ -140,7 +162,7 @@ argo-cd:
                 },
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]
@@ -166,7 +188,7 @@ argo-cd:
                 },
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]
@@ -199,7 +221,7 @@ argo-cd:
                 },
                 {
                   "type": "context",
-                  "elements": [{"type": "mrkdwn", "text": "<http://argocd.internal.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
+                  "elements": [{"type": "mrkdwn", "text": "<https://argocd.rger.dev/applications/argocd/{{.app.metadata.name}}|View in ArgoCD>"}]
                 }
               ]
             }]


### PR DESCRIPTION
## Summary
- publish ArgoCD at `https://argocd.rger.dev` and switch the server service to `ClusterIP` now that Cloudflare tunnel routing is in place
- configure Dex to use the 1Password-backed GitHub OAuth credentials and grant the GitHub email admin access through ArgoCD RBAC
- update ArgoCD notification links to use the new public hostname and add the `OnePasswordItem` needed for the OAuth secret sync

## Validation
- `helm lint charts/argocd`
- `helm template charts/argocd | kubectl apply --dry-run=client -f -`

## Follow-up
- keep the local ArgoCD `admin` login enabled for now until the first GitHub admin login is verified successfully