### PR TITLE
Setup AuxArmory deployment and database migrations

### DIFF
--- a/charts/auxarmory/Chart.yaml
+++ b/charts/auxarmory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auxarmory
 description: AuxArmory umbrella chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 dependencies:
   - name: postgresql

--- a/charts/auxarmory/templates/db-migrate-job.yaml
+++ b/charts/auxarmory/templates/db-migrate-job.yaml
@@ -21,14 +21,18 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: db-migrate
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
+          {{- if .Values.migration.command }}
           command:
             {{- toYaml .Values.migration.command | nindent 12 }}
+          {{- end }}
           env:
             - name: NODE_ENV
               value: {{ .Values.global.nodeEnv | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "auxarmory.sharedSecretName" . }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
 {{- end }}

--- a/charts/auxarmory/values.yaml
+++ b/charts/auxarmory/values.yaml
@@ -93,11 +93,18 @@ worker:
     itemPath: vaults/replace-me/items/replace-me
 
 migration:
-  enabled: false
-  command:
-    - /bin/sh
-    - -ec
-    - pnpm --filter @auxarmory/db db:migrate
+  enabled: true
+  image:
+    repository: ghcr.io/dumspy/auxarmory-db-migrations
+    tag: latest
+    pullPolicy: Always
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 postgresql:
   enabled: true


### PR DESCRIPTION
This PR sets up the deployment for the AuxArmory application, specifically focusing on integrating the database migration process. 

Key changes:
- Enabled the `migration` job by default.
- Updated the Helm chart to use the dedicated `ghcr.io/dumspy/auxarmory-db-migrations:latest` image for migrations, as introduced in the `auxarmory` repo's PR #65.
- Configured standard resource requests and limits (256Mi/100m requests, 512Mi/500m limits) for the migration container.
- Bumped the `auxarmory` umbrella chart version to `0.1.1`.

Note: Application services (API, Auth, Worker) are confirmed to handle migration gating internally via their image entrypoints.

---
*PR created automatically by Jules for task [1620692225279045675](https://jules.google.com/task/1620692225279045675) started by @Dumspy*