### PR TITLE
Ensure CI workflow blocks on failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Render Charts
         run: |
           nix develop --command bash -c '
+            set -e
             mkdir -p ${{ env.RENDERED_DIR }}
             for chart in charts/*/; do
               [ -d "$chart" ] || continue
@@ -61,13 +62,13 @@ jobs:
           nix develop --command checkov \
             --directory ${{ env.RENDERED_DIR }} \
             --framework kubernetes \
-            --quiet \
-            --soft-fail
+            --quiet
 
       - name: Best Practices Scan (Kube-score)
         run: |
           # Run kube-score on all collected manifests.
           nix develop --command bash -c '
+            set -o pipefail
             find ${{ env.RENDERED_DIR }} -type f \( -name "*.yaml" -o -name "*.yml" \) \
-            | xargs kube-score score || true
+            | xargs kube-score score
           '


### PR DESCRIPTION
The CI workflow was previously configured to ignore failures in several key validation steps. This PR updates the `.github/workflows/ci.yaml` to ensure the workflow correctly blocks and fails when issues are detected:

1. **Checkov Security Scan**: Removed the `--soft-fail` flag so security violations will now cause the job to fail.
2. **Kube-score Best Practices Scan**: Removed the `|| true` suffix and added `set -o pipefail` to ensure that any critical issues found by `kube-score` correctly propagate as a job failure.
3. **Render Charts**: Added `set -e` to the bash script to ensure that if any `helm` command fails during the rendering process, the workflow stops immediately.
4. **Validation**: Verified that `kube-score` by default only exits with a non-zero code for critical errors, respecting the requirement to only block on critical findings.

---
*PR created automatically by Jules for task [10096165345680714525](https://jules.google.com/task/10096165345680714525) started by @Dumspy*