### PR TITLE
chore(argocd): bump argo-cd to 9.5.11 / v3.3.9

### DIFF
--- a/charts/argocd/Chart.lock
+++ b/charts/argocd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 9.4.17
+  version: 9.5.11
 - name: argocd-image-updater
   repository: https://argoproj.github.io/argo-helm
   version: 1.1.4
-digest: sha256:465cc88f020645ed71adce12b2537e8239fb6a1571b75c5aaf0087a98452fa7a
-generated: "2026-04-06T15:14:47.282354142Z"
+digest: sha256:a7a8303ac4862a93d491dbb1b1c79957ef57abac366673d54fbdf86c15ec5c84
+generated: "2026-05-03T12:45:39.287295192Z"

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: argo-cd
 description: A Helm chart for Kubernetes
 type: application
-version: 0.5.0
+version: 0.5.1
 dependencies:
   - name: argo-cd
-    version: 9.4.17
+    version: 9.5.11
     repository: https://argoproj.github.io/argo-helm
   - name: argocd-image-updater
     version: 1.1.4


### PR DESCRIPTION
## Summary

- Bumps the argo-cd Helm chart dependency from `9.4.17` → `9.5.11`
- Ships Argo CD **v3.3.9** (from v3.3.8), patching **GHSA-3v3m-wc6v-x4x3**
- This is a **Critical** severity advisory allowing Kubernetes Secret extraction via the ServerSideDiff endpoint

## Details

The vulnerability affects Argo CD 3.2.0–3.3.8. The fix is in 3.3.9 / 3.2.11. The Helm chart `argo-cd@9.5.11` bundles the patched `appVersion: v3.3.9`.

## Validation

- `helm lint charts/argocd` ✅
- `helm template charts/argocd | kubectl apply --dry-run=client -f -` ✅