### PR TITLE
fix(cf-tunnel): add pod and container security context

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Cloudflare Tunnel for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2026.1.2"

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -17,13 +17,20 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      {{- with .Values.cloudflared.podSecurityContext }}
       securityContext:
+        {{- toYaml . | nindent 8 }}
         sysctls:
         # Allows ICMP traffic (ping, traceroute) to resources behind cloudflared.
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
+      {{- end }}
       containers:
         - name: cloudflared
+          {{- with .Values.cloudflared.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.cloudflared.image.repository }}:{{ .Values.cloudflared.image.tag }}"
           imagePullPolicy: {{ .Values.cloudflared.image.pullPolicy }}
           env:

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -16,3 +16,17 @@ cloudflared:
 
   logLevel: info
   metricsPort: 2000
+
+  podSecurityContext:
+    runAsUser: 65532
+    runAsNonRoot: true
+    fsGroup: 65532
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
## Summary

- Add `podSecurityContext` (runAsNonRoot, runAsUser: 65532, fsGroup: 65532)
- Add `containerSecurityContext` (allowPrivilegeEscalation: false, drop all
  capabilities, readOnlyRootFilesystem, runAsNonRoot, seccomp: RuntimeDefault)

## Resolved Checkov failures (9 total)

| Check | Description | Status |
|-------|-------------|--------|
| CKV_K8S_30 | Apply security context to containers | ✅ Fixed |
| CKV_K8S_29 | Apply security context to pods | ✅ Fixed |
| CKV_K8S_20 | allowPrivilegeEscalation | ✅ Fixed |
| CKV_K8S_23 | Minimize root containers | ✅ Fixed |
| CKV_K8S_37 | Minimize capabilities assigned | ✅ Fixed |
| CKV_K8S_28 | Minimize NET_RAW capability | ✅ Fixed |
| CKV_K8S_31 | Set seccomp profile | ✅ Fixed |
| CKV_K8S_40 | High UID to avoid host conflict | ✅ Fixed |
| CKV_K8S_22 | Read-only filesystem | ✅ Fixed |

Bump chart version: 0.1.1 → 0.1.2