### PR TITLE
fix(auxbot): add pod and container security context

### DIFF
--- a/charts/auxbot/Chart.yaml
+++ b/charts/auxbot/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: auxbot
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/charts/auxbot/templates/deployment.yaml
+++ b/charts/auxbot/templates/deployment.yaml
@@ -18,8 +18,16 @@ spec:
         app: {{ .Release.Name }}-controller
     spec:
       serviceAccountName: {{ .Release.Name }}-controller-sa
+      {{- with .Values.controller.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: controller
+        {{- with .Values.controller.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         ports:

--- a/charts/auxbot/values.yaml
+++ b/charts/auxbot/values.yaml
@@ -4,6 +4,20 @@ controller:
     tag: "latest"
     pullPolicy: Always
 
+  podSecurityContext:
+    runAsUser: 65532
+    runAsNonRoot: true
+    fsGroup: 65532
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
   service:
     type: ClusterIP
     ports:

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Cloudflare Tunnel for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2026.1.2"

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -17,13 +17,20 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      {{- with .Values.cloudflared.podSecurityContext }}
       securityContext:
+        {{- toYaml . | nindent 8 }}
         sysctls:
         # Allows ICMP traffic (ping, traceroute) to resources behind cloudflared.
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
+      {{- end }}
       containers:
         - name: cloudflared
+          {{- with .Values.cloudflared.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.cloudflared.image.repository }}:{{ .Values.cloudflared.image.tag }}"
           imagePullPolicy: {{ .Values.cloudflared.image.pullPolicy }}
           env:

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -16,3 +16,17 @@ cloudflared:
 
   logLevel: info
   metricsPort: 2000
+
+  podSecurityContext:
+    runAsUser: 65532
+    runAsNonRoot: true
+    fsGroup: 65532
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
| Check | Description |
|-------|-------------|
| CKV_K8S_29 | Apply security context to pods and containers |
| CKV_K8S_20 | Disable allowPrivilegeEscalation |
| CKV_K8S_22 | Use read-only filesystem for containers |
| CKV_K8S_37 | Drop all Linux capabilities |
| CKV_K8S_28 | Drop NET_RAW capability |
| CKV_K8S_31 | Set seccomp profile to RuntimeDefault |
| CKV_K8S_40 | Run as high UID |