### PR TITLE
fix(sample-app): add pod and container security context

### DIFF
--- a/charts/auxbot/Chart.yaml
+++ b/charts/auxbot/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: auxbot
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/charts/auxbot/templates/deployment.yaml
+++ b/charts/auxbot/templates/deployment.yaml
@@ -18,8 +18,16 @@ spec:
         app: {{ .Release.Name }}-controller
     spec:
       serviceAccountName: {{ .Release.Name }}-controller-sa
+      {{- with .Values.controller.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: controller
+        {{- with .Values.controller.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         ports:

--- a/charts/auxbot/values.yaml
+++ b/charts/auxbot/values.yaml
@@ -4,6 +4,20 @@ controller:
     tag: "latest"
     pullPolicy: Always
 
+  podSecurityContext:
+    runAsUser: 65532
+    runAsNonRoot: true
+    fsGroup: 65532
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
   service:
     type: ClusterIP
     ports:

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Cloudflare Tunnel for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2026.1.2"

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -17,13 +17,20 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      {{- with .Values.cloudflared.podSecurityContext }}
       securityContext:
+        {{- toYaml . | nindent 8 }}
         sysctls:
         # Allows ICMP traffic (ping, traceroute) to resources behind cloudflared.
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
+      {{- end }}
       containers:
         - name: cloudflared
+          {{- with .Values.cloudflared.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.cloudflared.image.repository }}:{{ .Values.cloudflared.image.tag }}"
           imagePullPolicy: {{ .Values.cloudflared.image.pullPolicy }}
           env:

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -16,3 +16,17 @@ cloudflared:
 
   logLevel: info
   metricsPort: 2000
+
+  podSecurityContext:
+    runAsUser: 65532
+    runAsNonRoot: true
+    fsGroup: 65532
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/charts/sample-app/Chart.yaml
+++ b/charts/sample-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sample-app
 description: A sample application for testing oci-cluster deployment
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.27"

--- a/charts/sample-app/templates/deployment.yaml
+++ b/charts/sample-app/templates/deployment.yaml
@@ -16,8 +16,16 @@ spec:
       labels:
         {{- include "sample-app.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/sample-app/values.yaml
+++ b/charts/sample-app/values.yaml
@@ -20,5 +20,19 @@ resources:
     memory: "128Mi"
     cpu: "100m"
 
+podSecurityContext:
+  runAsUser: 65532
+  runAsNonRoot: true
+  fsGroup: 65532
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
 podAnnotations:
   cluster: oci-cluster


### PR DESCRIPTION
## Summary

Add pod and container `securityContext` to the sample-app chart, following the established pattern from previous fixes.

### Resolved Checks

| Check | Description |
|-------|-------------|
| CKV_K8S_30 | Apply security context to containers |
| CKV_K8S_29 | Apply security context to pods and containers |
| CKV_K8S_23 | Minimize the admission of root containers |
| CKV_K8S_20 | Containers should not run with allowPrivilegeEscalation |
| CKV_K8S_37 | Minimize the admission of containers with capabilities assigned |
| CKV_K8S_28 | Minimize the admission of containers with the NET_RAW capability |
| CKV_K8S_31 | Ensure seccomp profile is set to RuntimeDefault |
| CKV_K8S_22 | Use read-only filesystem for containers where possible |
| CKV_K8S_40 | Containers should run as a high UID to avoid host conflict |